### PR TITLE
Fix refresh_token is null

### DIFF
--- a/FirebaseAuth/FirebaseAuth.gd
+++ b/FirebaseAuth/FirebaseAuth.gd
@@ -58,13 +58,8 @@ func _on_FirebaseAuth_request_completed(result, response_code, headers, body):
 func begin_refresh_countdown():
     var refresh_token = null
     var expires_in = 1000
-    auth = get_clean_keys(auth)
-    if auth.has("refreshToken"):
-        refresh_token = auth.refreshToken
-        expires_in = auth.expiresIn
-    elif auth.has("refresh_token"):
-        refresh_token = auth.refresh_token
-        expires_in = auth.expires_in
+    refresh_token = auth.refreshtoken
+    expires_in = auth.expiresin
     needs_refresh = true
     yield(get_tree().create_timer(float(expires_in)), "timeout")
     refresh_request_body.refresh_token = refresh_token


### PR DESCRIPTION
the keys are renamed in `func get_clean_keys`.
after that, `auth` does not have `refreshToken` or `refresh_token` but only has `refreshtoken`

and `auth = get_clean_keys(auth)` is already called in here, right just before calling `begin_fresh_countdown()`.

https://github.com/WolfgangSenff/GodotFirebase/blob/b380007b693809cd19b19b7c3a912b625aad5125/FirebaseAuth/FirebaseAuth.gd#L50-L54

so no need to call it again.