### PR TITLE
Fix Store.gd null data rewrite issue

### DIFF
--- a/Demo/Control.tscn
+++ b/Demo/Control.tscn
@@ -76,7 +76,6 @@ position = Vector2( 310.417, 182.17 )
 texture = ExtResource( 8 )
 
 [node name="Tween" type="Tween" parent="Game"]
-
 [connection signal="pressed" from="CanvasLayer/ChatControl/VBoxContainer/SubmitButton" to="CanvasLayer/ChatControl" method="_on_SubmitButton_pressed"]
 
 [editable path="CanvasLayer/FirebaseLoginAndDB"]

--- a/Demo/MainTheme.tres
+++ b/Demo/MainTheme.tres
@@ -8,4 +8,3 @@ font_data = ExtResource( 1 )
 
 [resource]
 default_font = SubResource( 1 )
-

--- a/Demo/addons/GDFirebase/Store.gd
+++ b/Demo/addons/GDFirebase/Store.gd
@@ -14,7 +14,8 @@ func put_recursive(path, data, previous_key, current_data_set):
             if data:
                 data_set = data
         else:
-            current_data_set[previous_key] = data
+            if data:
+                current_data_set[previous_key] = data
     else:
         var key = get_key(path)
         if !key:
@@ -26,7 +27,8 @@ func put_recursive(path, data, previous_key, current_data_set):
         if previous_key:
             put_recursive(chopped_path, data, key, current_data_set[previous_key])
         else:
-            data_set[key] = data
+            if data:
+                data_set[key] = data
             
 
 func get_key(path : String):
@@ -52,10 +54,12 @@ func patch(path, data):
 func patch_recursive(path, data, previous_key, current_data_set):
     if path == path_separator:
         if previous_key.length() == 0:
-            data_set = data
+            if data:
+                data_set = data
         else:
-            for key in data.keys():
-                current_data_set[key] = data[key]
+            if data:
+                for key in data.keys():
+                    current_data_set[key] = data[key]
     else:
         var key = get_key(path)
         if !key:

--- a/Demo/default_env.tres
+++ b/Demo/default_env.tres
@@ -5,4 +5,3 @@
 [resource]
 background_mode = 2
 background_sky = SubResource( 1 )
-

--- a/GDFirebase/Store.gd
+++ b/GDFirebase/Store.gd
@@ -14,7 +14,8 @@ func put_recursive(path, data, previous_key, current_data_set):
             if data:
                 data_set = data
         else:
-            current_data_set[previous_key] = data
+            if data:
+                current_data_set[previous_key] = data
     else:
         var key = get_key(path)
         if !key:
@@ -26,7 +27,8 @@ func put_recursive(path, data, previous_key, current_data_set):
         if previous_key:
             put_recursive(chopped_path, data, key, current_data_set[previous_key])
         else:
-            data_set[key] = data
+            if data:
+                data_set[key] = data
             
 
 func get_key(path : String):
@@ -52,10 +54,12 @@ func patch(path, data):
 func patch_recursive(path, data, previous_key, current_data_set):
     if path == path_separator:
         if previous_key.length() == 0:
-            data_set = data
+            if data:
+                data_set = data
         else:
-            for key in data.keys():
-                current_data_set[key] = data[key]
+            if data:
+                for key in data.keys():
+                    current_data_set[key] = data[key]
     else:
         var key = get_key(path)
         if !key:


### PR DESCRIPTION
Sometimes, when the Store got a null piece of data (which can happen for some unknown reason), it would occasionally rewrite the root dictionary with it. This fixes that by never allowing the root dictionary to be rewritten with null data.