### PR TITLE
Add override.cfg back for in-editor Plugin configuration.

### DIFF
--- a/addons/godot-firebase/Firebase.gd
+++ b/addons/godot-firebase/Firebase.gd
@@ -1,6 +1,6 @@
 extends Node
 
-const ENVIRONMENT_VARIABLES : String = "environment_variables/"
+const ENVIRONMENT_VARIABLES : String = "firebase/environment_variables/"
 onready var Auth = HTTPRequest.new()
 onready var Firestore = Node.new()
 onready var Database = Node.new()

--- a/override.cfg
+++ b/override.cfg
@@ -1,0 +1,10 @@
+[environment_variables]
+
+apiKey=""
+authDomain=""
+databaseURL=""
+projectId=""
+storageBucket=""
+messagingSenderId=""
+appId=""
+measurementId=""

--- a/override.cfg
+++ b/override.cfg
@@ -1,4 +1,4 @@
-[environment_variables]
+[firebase/environment_variables]
 
 apiKey=""
 authDomain=""


### PR DESCRIPTION
Latest PRs cut out the `ovverride.cfg` that was left in the old `plugin` subfolder of the repository.
This PR will add the file back in order to let people configure Firebase inside the Project Settings window within the Editor.

The `override.cfg` is a configuration file that Godot Engine automatically reads to extend the Project Settings.
Any line in the .cfg, if properly set up, will be added in Project Settings sidelist after the file is added to the root of the project and the project has been reloaded (just a quit and open will work).

*Changes:*  
- fff8101 just adds the file back;
- 215e649 changes the override.cfg structure, adding a `firebase/` root in the settings' category. This will make the setting inside Project Settings even more readable. See below as an example:
![old configuration](https://user-images.githubusercontent.com/45271396/103518892-d7e1bb80-4e74-11eb-8ded-5ab17be8a932.png)
*old configuration*
![new configuration](https://user-images.githubusercontent.com/45271396/103519129-4888d800-4e75-11eb-8eea-b75cf8863ffe.png)
*new configuration*
- 30ab256 `Firebase.gd` will be changed in order to properly find the settings

As a consequence, the [wiki page](https://github.com/WolfgangSenff/GodotFirebase/wiki/Installation-and-Activation#activation) will need to be updated. 